### PR TITLE
Fix noAck mode

### DIFF
--- a/firmware/src/radio.c
+++ b/firmware/src/radio.c
@@ -41,7 +41,7 @@
 #define CMD_REUSE_TX_PL 0xE3
 #define CMD_RX_PL_WID 0x60
 #define CMD_W_ACK_PAYLOAD(P)  (0xA8|(P&0x0F))
-#define CMD_W_TX_PAYLOAD_NO_ACK 0xD0
+#define CMD_W_TX_PAYLOAD_NO_ACK 0xB0
 #define CMD_NOP 0xFF
 
 //Usefull macro
@@ -119,8 +119,8 @@ void radioInit(enum radioMode_e mode)
 
   //Wait a little while for the radio to be rdy
   for(i=0;i<1000;i++);
-  //Enable the dynamic packet size and the ack payload
-  radioWriteReg(REG_FEATURE, 0x06);
+  //Enable dynamic packet size, ack payload, and NOACK command
+  radioWriteReg(REG_FEATURE, 0x07);
   radioWriteReg(REG_DYNPD, 0x01);
 
   //Set the default radio parameters

--- a/firmware/src/usbDescriptor.c
+++ b/firmware/src/usbDescriptor.c
@@ -37,7 +37,7 @@ __code const char usbDeviceDescriptor[] = {
   64,                 //bMaxPacketSize0
   0x15, 0x19,         //idVendor (Nordic)
   0x77, 0x77,         //idProduct (Randomly chosen for the development)
-  0x53, 0x99,         //bcdDevice (Dev version v99.53)
+  0x54, 0x99,         //bcdDevice (Dev version v99.54)
   0x01,               //iManufacturer (String 1)
   0x02,               //iProduct (String 2)
   0x1D,               //iSerialNumber (the ID is at index 0x1D)


### PR DESCRIPTION
* Correct CMD_W_TX_PAYLOAD_NO_ACK to be the correct one according to the datasheet
* Enable NoAck command
* This allows the existing method radioSendPacketNoAck to work correctly
* Update version number to have a way to detect if radio supports NoAck mode correctly