### PR TITLE
Fix Broadcasting behavior

### DIFF
--- a/firmware/src/radio.c
+++ b/firmware/src/radio.c
@@ -316,11 +316,18 @@ unsigned char radioSendPacket(__xdata char *payload, char len,
 //Send a packet and don't wait for the Acknoledge
 void radioSendPacketNoAck(__xdata char *payload, char len)
 {
+  char status = 0;
   //Wait for the TX fifo not to be full
-  while((radioNop()&0x01) != 0);
+  // while((radioNop()&0x01) != 0);
 
   //Send the packet
   radioTxPacketNoAck(payload, len);
+
+  //Wait for something to happen
+  while(((status=radioNop())&0x70) == 0);
+
+  // Clear the flags
+  radioWriteReg(REG_STATUS, 0x70);
 
   //Nothing to wait for, the packet is 'just' sent!
 }

--- a/firmware/src/radio.c
+++ b/firmware/src/radio.c
@@ -317,8 +317,6 @@ unsigned char radioSendPacket(__xdata char *payload, char len,
 void radioSendPacketNoAck(__xdata char *payload, char len)
 {
   char status = 0;
-  //Wait for the TX fifo not to be full
-  // while((radioNop()&0x01) != 0);
 
   //Send the packet
   radioTxPacketNoAck(payload, len);
@@ -328,8 +326,6 @@ void radioSendPacketNoAck(__xdata char *payload, char len)
 
   // Clear the flags
   radioWriteReg(REG_STATUS, 0x70);
-
-  //Nothing to wait for, the packet is 'just' sent!
 }
 
 //Raw registers update (for internal use)


### PR DESCRIPTION
The radio could hang with the previous code, especially when broadcasting and non-broadcasting packets were mixed. This code unifies the code, making the behavior of radioSendPacketNoAck the same as radioSendPacket (except of waiting for an ack).

Tested as part of the Crazyswarm project.