### PR TITLE
Multiple Broadcasts per USB request

### DIFF
--- a/firmware/src/main.c
+++ b/firmware/src/main.c
@@ -335,7 +335,7 @@ void legacyRun()
   //Send a packet if something is received on the USB
   if (!(OUT1CS&EPBSY) && !contCarrier)
   {
-    //Fetch the USB data size. Limit it to 32
+    //Fetch the USB data size. Limit it to 64
     tlen = OUT1BC;
     if (tlen>64) tlen=64;
 
@@ -347,6 +347,9 @@ void legacyRun()
 
     if (needAck)
     {
+      // Limit data size to 32
+      if (tlen>32) tlen=32;
+
       status = radioSendPacket(tbuffer, tlen, rbuffer, &rlen);
 
       //Set the Green LED on success and the Red one on failure
@@ -381,6 +384,10 @@ void legacyRun()
       if (tlen <= 32) {
         radioSendPacketNoAck(tbuffer, tlen);
       } else {
+        // If we receive a USB packet > 32 bytes, we assume that the user wants
+        // to broadcast two packets of the same size. We can not transmit the
+        // size because a USB request is limited to 64 bytes and each CRTP
+        // packet could be up to 32 bytes.
         radioSendPacketNoAck(tbuffer, tlen / 2);
         radioSendPacketNoAck(tbuffer + tlen / 2, tlen / 2);
       }

--- a/firmware/src/usbDescriptor.c
+++ b/firmware/src/usbDescriptor.c
@@ -37,7 +37,7 @@ __code const char usbDeviceDescriptor[] = {
   64,                 //bMaxPacketSize0
   0x15, 0x19,         //idVendor (Nordic)
   0x77, 0x77,         //idProduct (Randomly chosen for the development)
-  0x54, 0x99,         //bcdDevice (Dev version v99.54)
+  0x55, 0x99,         //bcdDevice (Dev version v99.55)
   0x01,               //iManufacturer (String 1)
   0x02,               //iProduct (String 2)
   0x1D,               //iSerialNumber (the ID is at index 0x1D)


### PR DESCRIPTION
This change allows to broadcast two packets per USB request, assuming that both packets are the same size. Currently, the behavior is detected by the USB request size: If it is bigger than 32 bytes, we assume that the user wants to broadcast two packets (since one CRTP packet is limited to 32 bytes).
It would be possible to add an additional flag to enable/disable flag as well - I am not sure how useful that would be. In the previous behavior we would silently truncate the USB request to 32 bytes.

This behavior has been used within the Crazyswarm project. It reduces the overall latency by reducing the number of required USB requests per radio.