### PR TITLE
Fix SDCC compiler warnings.

### DIFF
--- a/firmware/inc/usbDescriptor.h
+++ b/firmware/inc/usbDescriptor.h
@@ -40,9 +40,9 @@
 
 
 //Descriptors instanciated in usbDescriptor.c
-extern __code const char usbDeviceDescriptor[];
-extern __code const char usbConfigurationDescriptor[57];
-extern __code const char usbHidReportDescriptor[32];
+extern __code const unsigned char usbDeviceDescriptor[];
+extern __code const unsigned char usbConfigurationDescriptor[57];
+extern __code const unsigned char usbHidReportDescriptor[32];
 extern __code char usbStringDescriptor0[4];
 extern __code char usbStringDescriptor1[18];
 extern __code char usbStringDescriptor2[];

--- a/firmware/src/radio.c
+++ b/firmware/src/radio.c
@@ -57,11 +57,11 @@ void radioUpdateRfSetup(void);
 
 //Chached state of the radio
 static __xdata struct {
-  char dataRate;
-  char power;
-  char arc;
-  char ard;
-  char contCarrier;
+  unsigned char dataRate;
+  unsigned char power;
+  unsigned char arc;
+  unsigned char ard;
+  unsigned char contCarrier;
 } radioConf = {
   /*.dataRate =*/ DATA_RATE_2M,
   /*.power =*/ RADIO_POWER_0dBm,
@@ -78,7 +78,7 @@ static __code unsigned char ardStep[3][6] = { {0, 0, 8, 16, 24, 32}, //250Kps
 
 static __code unsigned char setupDataRate[] = {0x20, 0x00, 0x08};
 
-char spiRadioSend(char dt)
+char spiRadioSend(unsigned char dt)
 {
   //Send the data
   RFDAT = dt;

--- a/firmware/src/usbDescriptor.c
+++ b/firmware/src/usbDescriptor.c
@@ -27,7 +27,7 @@
 #include "usbDescriptor.h"
 
 /* Device descriptor */
-__code const char usbDeviceDescriptor[] = {
+__code const unsigned char usbDeviceDescriptor[] = {
   18,                 //bLength
   DEVICE_DESCRIPTOR,  //bDescriptorType
   0x00, 0x02,         //bcdUSB, usb 2.0
@@ -46,7 +46,7 @@ __code const char usbDeviceDescriptor[] = {
 
 //The only configuration descriptor
 //Monolitique implementation to ease the code development
-__code const char usbConfigurationDescriptor[57] = {
+__code const unsigned char usbConfigurationDescriptor[57] = {
   /***** Configuration descriptor ******/
   9,                         //bLength
   CONFIGURATION_DESCRIPTOR,  //bDescriptorType
@@ -116,7 +116,7 @@ __code const char usbConfigurationDescriptor[57] = {
 
 #ifdef PPM_JOYSTICK
 //HID report descriptor for PPM Joystick
-__code const char usbHidReportDescriptor[32] = {
+__code const unsigned char usbHidReportDescriptor[32] = {
     0x05, 0x01,                    // USAGE_PAGE (Generic Desktop)
     0x09, 0x04,                    // USAGE (Joystick)
     0xa1, 0x01,                    // COLLECTION (Application)


### PR DESCRIPTION
The following warning appears multiple times when trying to compile with sdcc 3.5 (the default version of Ubuntu 16.04): "warning 158: overflow in implicit constant conversion". Changing char to unsigned char fixes the problem. I also recompiled and reflashed the radio with the changes and didn't see any strange behavior so far.

