### PR TITLE
fixed error and warning (fixes issue #44)

### DIFF
--- a/nrfProg/commands.c
+++ b/nrfProg/commands.c
@@ -28,6 +28,7 @@
 #include <string.h>
 
 #include "nrfSpi.h"
+#include "commands.h"
 
 // Implemented instruction set ...
 #define WREN 0x06
@@ -136,7 +137,7 @@ int cmdProgram(int addr, char *data, int len) {
 
   if (addr>30*1024) {
     printf("ERROR: Writing above 30K is disabled!\n");
-    return;
+    return -1;
   }
 
   if((addr+len)>30*1024) {


### PR DESCRIPTION
Missing return value on an error condition, missing include file to get function definition.