### PR TITLE
Fix setting the CRC length

### DIFF
--- a/firmware/src/main.c
+++ b/firmware/src/main.c
@@ -259,9 +259,9 @@ void handleUsbVendorSetup()
     else if(setup->request == CRC_LEN)
     {
       if(setup->value == 1) {
-        radioSetCRCLen(2);
+        radioSetCRCLen(0);
       } else {
-        radioSetCRCLen(2);
+        radioSetCRCLen(1);
       }
       usbAckSetup();
       return;


### PR DESCRIPTION
Without this fix, the CRC will always be set to 1 byte, and it is not possible to set it back to 2 bytes.